### PR TITLE
Improve environment interactions and visuals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,6 @@
             <div class="slot" id="hotbar-2">3</div>
             <div class="slot" id="hotbar-3">4</div>
         </div>
-        <div id="clock"><span id="clock-phase">Day</span><span id="clock-time">10:00</span></div>
         <div id="chat-container"><ul id="chat-messages"></ul><input type="text" id="chat-input" placeholder="Press Enter to chat..." maxlength="100"></div>
     </div>
     

--- a/public/style.css
+++ b/public/style.css
@@ -144,24 +144,6 @@ canvas {
     color: #999;
 }
 
-/* Clock */
-#clock {
-    position: absolute;
-    top: 20px;
-    right: 20px;
-    background: rgba(0,0,0,0.5);
-    padding: 10px;
-    border-radius: 5px;
-    text-align: center;
-}
-#clock-phase {
-    display: block;
-    font-size: 18px;
-}
-#clock-time {
-    font-size: 14px;
-}
-
 /* Floating Text */
 .floating-text {
     position: absolute;


### PR DESCRIPTION
## Summary
- Add smooth day-night transitions and remove HUD timer
- Scale wood and stone structures to quarter size while keeping workbench size
- Adjust resource yields and tree collisions based on tree size with transparent foliage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` *(starts, then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ae045e39f08328b1ac5111409e69de