### PR TITLE
Add inventory drag-and-drop and tighten item placement

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -34,6 +34,12 @@ const treeTopImg = new Image(); treeTopImg.src = '/icons/Treetop.png';
 const treeTrunkImg = new Image(); treeTrunkImg.src = '/icons/Treetrunk.png';
 const workbenchImg = new Image(); workbenchImg.src = '/icons/workbench.png';
 const ITEM_ICONS = {
+    'Wood': 'wood.png',
+    'Stone': 'stone.png',
+    'Leaf': 'Leaf.png',
+    'Boar Meat': 'Meat.png',
+    'Tusk': 'Tusk.png',
+    'Apple': 'apple.png',
     'Wooden Axe': 'wood.png',
     'Wooden Pickaxe': 'wood.png',
     'Wooden Sword': 'wood.png',
@@ -60,6 +66,7 @@ const chatMessages = document.getElementById('chat-messages'); const chatInput =
 const healthFill = document.getElementById('player-health-fill');
 let selectedHotbarSlot = 0;
 let mousePos = { x: 0, y: 0 };
+let dragSrcIndex = null;
 canvas.addEventListener('mousemove', e => {
     const rect = canvas.getBoundingClientRect();
     mousePos.x = e.clientX - rect.left;
@@ -170,9 +177,22 @@ function updateInventoryUI(){
     const me = players[myPlayerId];
     if(!me || !me.inventory) return;
     inventoryGrid.innerHTML = '';
-    me.inventory.forEach((item) => {
+    me.inventory.forEach((item, i) => {
         const slot = document.createElement('div');
         slot.className = 'slot';
+        slot.dataset.index = i;
+        slot.draggable = !!item;
+        slot.addEventListener('dragstart', () => { dragSrcIndex = i; });
+        slot.addEventListener('dragover', e => e.preventDefault());
+        slot.addEventListener('drop', e => {
+            e.preventDefault();
+            const dest = parseInt(e.currentTarget.dataset.index, 10);
+            if (dragSrcIndex !== null && dest !== dragSrcIndex) {
+                socket.send(JSON.stringify({ type: 'swap-inventory', from: dragSrcIndex, to: dest }));
+            }
+            dragSrcIndex = null;
+        });
+        slot.addEventListener('dragend', () => { dragSrcIndex = null; });
         if(item){
             const iconName = ITEM_ICONS[item.item];
             if(iconName){

--- a/server.js
+++ b/server.js
@@ -220,7 +220,7 @@ wss.on('connection', ws => {
                 if (item === 'Wood') structureType = 'wood_wall';
                 else if (item === 'Stone') structureType = 'stone_wall';
                 else if (item === 'Workbench') structureType = 'workbench';
-                else structureType = item.toLowerCase();
+                else break;
                 if (structureType === 'workbench') {
                     const gridX = Math.floor(x / GRID_CELL_SIZE);
                     const gridY = Math.floor(y / GRID_CELL_SIZE);
@@ -269,6 +269,20 @@ wss.on('connection', ws => {
                         markArea(gx, gy, 1, false);
                     }
                     broadcast({ type: 'structure-update', structures });
+                }
+                break;
+            }
+            case 'swap-inventory': {
+                const { from, to } = data;
+                if (
+                    Number.isInteger(from) && Number.isInteger(to) &&
+                    from >= 0 && from < player.inventory.length &&
+                    to >= 0 && to < player.inventory.length
+                ) {
+                    const temp = player.inventory[from];
+                    player.inventory[from] = player.inventory[to];
+                    player.inventory[to] = temp;
+                    ws.send(JSON.stringify({ type: 'inventory-update', inventory: player.inventory, hotbar: player.hotbar }));
                 }
                 break;
             }


### PR DESCRIPTION
## Summary
- use real icons for core resources (wood, stone, leaf, meat, tusk, apple)
- enable dragging inventory items to swap slots
- restrict structure placement to wood, stone, and workbench items

## Testing
- `npm test` (fails: Missing script)
- `node server.js` (server starts)


------
https://chatgpt.com/codex/tasks/task_e_68b460c66fa88328a903fb939901d0bd