### PR TITLE
Add death handling, collisions, and furnace crafting mechanics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,15 @@
         </div>
     </div>
 
+    <div id="furnace-screen" class="hidden">
+        <div id="furnace-panel">
+            <h2>Oven</h2>
+            <div><label>Input: </label><select id="furnace-input"></select></div>
+            <div><label>Fuel: </label><select id="furnace-fuel"></select></div>
+            <button id="furnace-cook-btn">Cook</button>
+        </div>
+    </div>
+
     <div id="notifications"></div>
     
     <script src="client.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -239,3 +239,18 @@ canvas {
 #chat-input:focus {
     outline: 1px solid #fff;
 }
+
+/* Furnace UI */
+#furnace-screen {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: rgba(30,30,30,0.9);
+    border: 2px solid #aaa;
+    padding: 20px;
+    border-radius: 10px;
+    pointer-events: auto;
+}
+#furnace-screen.hidden { display: none; }
+#furnace-panel { display: flex; flex-direction: column; gap: 10px; }


### PR DESCRIPTION
## Summary
- Prevent entities from passing through each other and block mobs only on tree trunks
- Allow players to die and turn into zombies, plus add furnace cooking with Oven.png interface
- Restrict crafting of tools and furnaces to workbenches

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` (start and stop)


------
https://chatgpt.com/codex/tasks/task_e_68b5fafbddc48328a35913917d59d30b