### PR TITLE
Enable ogre combat and stabilize fireball collisions

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -501,6 +501,11 @@ canvas.addEventListener('mousedown', e => {
         const dist = Math.hypot(mouseX - zombie.x, mouseY - zombie.y);
         if (dist < zombie.size && dist < zombieDist) { zombieDist = dist; closestZombie = zombie; }
     }
+    let closestOgre = null; let ogreDist = Infinity;
+    for (const ogre of ogres) {
+        const dist = Math.hypot(mouseX - ogre.x, mouseY - ogre.y);
+        if (dist < ogre.size && dist < ogreDist) { ogreDist = dist; closestOgre = ogre; }
+    }
     let closestResource = null; let closestDist = Infinity;
     for (const resource of resources) {
         if (!resource.harvested) {
@@ -512,6 +517,8 @@ canvas.addEventListener('mousedown', e => {
         socket.send(JSON.stringify({ type: 'hit-boar', boarId: closestBoar.id, item: selectedItem ? selectedItem.item : null }));
     } else if (closestZombie) {
         socket.send(JSON.stringify({ type: 'hit-zombie', zombieId: closestZombie.id, item: selectedItem ? selectedItem.item : null }));
+    } else if (closestOgre) {
+        socket.send(JSON.stringify({ type: 'hit-ogre', ogreId: closestOgre.id, item: selectedItem ? selectedItem.item : null }));
     } else if (closestResource) {
         socket.send(JSON.stringify({ type: 'hit-resource', resourceId: closestResource.id, item: selectedItem ? selectedItem.item : null }));
     } else {

--- a/server.js
+++ b/server.js
@@ -766,7 +766,7 @@ function gameLoop() {
                     boar.hp = Math.max(0, boar.hp - 2);
                     boar.burn = 120;
                     boar.aggressive = true;
-                    const nearestOgre = ogres.reduce((a,b)=>getDistance(b,boar)<getDistance(a,boar)?b:a, ogres[0]);
+                    const nearestOgre = ogres.length ? ogres.reduce((a,b)=>getDistance(b,boar)<getDistance(a,boar)?b:a) : null;
                     if (nearestOgre) boar.target = { type: 'ogre', id: nearestOgre.id };
                     broadcast({ type: 'boar-update', boar });
                     hit = true;
@@ -780,9 +780,21 @@ function gameLoop() {
                     zombie.hp = Math.max(0, zombie.hp - 2);
                     zombie.burn = 120;
                     zombie.aggressive = true;
-                    const nearestOgre = ogres.reduce((a,b)=>getDistance(b,zombie)<getDistance(a,zombie)?b:a, ogres[0]);
+                    const nearestOgre = ogres.length ? ogres.reduce((a,b)=>getDistance(b,zombie)<getDistance(a,zombie)?b:a) : null;
                     if (nearestOgre) zombie.target = { type: 'ogre', id: nearestOgre.id };
                     broadcast({ type: 'zombie-update', zombie });
+                    hit = true;
+                    break;
+                }
+            }
+        }
+        if (!hit) {
+            for (const ogre of ogres) {
+                if (getDistance(ogre, proj) < ogre.size) {
+                    ogre.hp = Math.max(0, ogre.hp - 2);
+                    ogre.burn = 120;
+                    if (proj.owner) ogre.target = { type: 'player', id: proj.owner };
+                    broadcast({ type: 'ogre-update', ogre });
                     hit = true;
                     break;
                 }


### PR DESCRIPTION
## Summary
- Allow clients to send hit messages for ogres so players can damage them
- Harden fireball collision logic and support ogre hits to avoid crashes

## Testing
- `node server.js & sleep 1 && kill $!`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b75cae1b00832899bb95b2bdf15550