### PR TITLE
Make torches bright and non-blocking

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -978,10 +978,28 @@ function render() {
             if (s.type === 'torch') {
                 const tx = s.x - camera.x + (s.size || GRID_CELL_SIZE) / 2;
                 const ty = s.y - camera.y + (s.size || GRID_CELL_SIZE) / 2;
-                const radius = 100;
+                const radius = 150;
                 const grad = ctx.createRadialGradient(tx, ty, 0, tx, ty, radius);
                 grad.addColorStop(0, 'rgba(0,0,0,1)');
                 grad.addColorStop(1, 'rgba(0,0,0,0)');
+                ctx.fillStyle = grad;
+                ctx.beginPath();
+                ctx.arc(tx, ty, radius, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        });
+        ctx.restore();
+
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        Object.values(structures).forEach(s => {
+            if (s.type === 'torch') {
+                const tx = s.x - camera.x + (s.size || GRID_CELL_SIZE) / 2;
+                const ty = s.y - camera.y + (s.size || GRID_CELL_SIZE) / 2;
+                const radius = 150;
+                const grad = ctx.createRadialGradient(tx, ty, 0, tx, ty, radius);
+                grad.addColorStop(0, 'rgba(255, 220, 100, 0.8)');
+                grad.addColorStop(1, 'rgba(255, 220, 100, 0)');
                 ctx.fillStyle = grad;
                 ctx.beginPath();
                 ctx.arc(tx, ty, radius, 0, Math.PI * 2);

--- a/server.js
+++ b/server.js
@@ -654,7 +654,9 @@ wss.on('connection', ws => {
                         const baseX = gridX * GRID_CELL_SIZE;
                         const baseY = gridY * GRID_CELL_SIZE;
                         structures[coordKey] = { type: structureType, x: baseX, y: baseY, size: GRID_CELL_SIZE };
-                        markArea(gridX, gridY, 1, true);
+                        if (structureType !== 'torch') {
+                            markArea(gridX, gridY, 1, true);
+                        }
                         broadcast({ type: 'structure-update', structures });
                         ws.send(JSON.stringify({ type: 'inventory-update', inventory: player.inventory, hotbar: player.hotbar }));
                     }
@@ -687,7 +689,7 @@ wss.on('connection', ws => {
                     if (key.startsWith('b')) {
                         const [bx, by] = key.slice(1).split(',').map(Number);
                         blockGrid[bx][by] = false;
-                    } else if (key.startsWith('w')) {
+                    } else if (key.startsWith('w') && structure.type !== 'torch') {
                         const [gx, gy] = key.slice(1).split(',').map(Number);
                         markArea(gx, gy, 1, false);
                     }


### PR DESCRIPTION
## Summary
- Ensure torches no longer block movement by avoiding grid occupancy
- Expand torch lighting to brighten a larger area with an additive glow

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b78061067c8328a2d3226425a5c93b