### PR TITLE
Buff wizard leveling and add spacebar slow

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -1094,7 +1094,7 @@ window.addEventListener('keydown', e => {
         if (!me) return;
         if (me.class === 'summoner') {
             socket.send(JSON.stringify({ type: 'spawn-minion', minionType: summonerSpawnType }));
-        } else if (me.class === 'mage' && me.mageSkills && me.mageSkills['mage-slow']) {
+        } else if (me.class === 'mage' && me.canSlow) {
             socket.send(JSON.stringify({ type: 'cast-slow' }));
         }
         e.preventDefault();

--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,7 @@
             <div id="mage-skills" class="class-skills hidden">
                 <div id="skill-mage-mana" class="skill-node locked" data-skill="mage-mana">More Mana</div>
                 <div id="skill-mage-regen" class="skill-node locked" data-skill="mage-regen">Faster Mana Regen</div>
-                <div id="skill-mage-slow" class="skill-node locked" data-skill="mage-slow">Slow Spell</div>
+                <div id="skill-mage-slow" class="skill-node locked" data-skill="mage-slow">Slow Spell (Spacebar)</div>
             </div>
         </div>
     </div>
@@ -88,6 +88,7 @@
             <li>E - Inventory</li>
             <li>Q - Skill Tree</li>
             <li>Enter - Chat</li>
+            <li>Space - Class Ability (e.g., Slow Spell)</li>
         </ul>
         <button id="controls-btn">Continue</button>
     </div>

--- a/server.js
+++ b/server.js
@@ -226,6 +226,12 @@ function sendLevelUpdate(ws, player) {
 function levelUp(player, ws) {
     player.level = (player.level || 1) + 1;
     player.skillPoints = (player.skillPoints || 0) + 1;
+    if (player.class === 'mage') {
+        player.maxMana += 20;
+        player.mana += 20;
+        player.manaRegen = (player.manaRegen || 0) + (0.5 / 60);
+        player.canSlow = true;
+    }
     sendLevelUpdate(ws, player);
 }
 
@@ -385,6 +391,7 @@ wss.on('connection', ws => {
         knightSkills: {},
         summonerSkills: { attack: 0, healer: 0, ranged: 0 },
         mageSkills: {},
+        canSlow: false,
         swordDamage: 0,
         attackRange: 0,
         class: null,


### PR DESCRIPTION
## Summary
- Grant mages bonus mana and regeneration when they level up and unlock the slow spell
- Allow spacebar slow casting based on `canSlow`
- Document slow spell and spacebar control in UI

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b78523f2e483289d79510ac8ba6011