### PR TITLE
feat: add distinct summon types

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -844,7 +844,18 @@ function drawZombie(zombie) {
     drawShadow(x, y, zombie.size * 2, zombie.size);
     ctx.beginPath();
     ctx.arc(x, y, zombie.size, 0, Math.PI * 2);
-    ctx.fillStyle = '#6b8e23';
+
+    // Pick colors based on the creature type for visual distinction.
+    let bodyColor = '#6b8e23'; // default zombie
+    let eyeColor = '#ccc';
+    if (zombie.kind === 'skeleton') {
+        bodyColor = '#ddd';
+        eyeColor = '#000';
+    } else if (zombie.kind === 'spirit') {
+        bodyColor = 'rgba(150,255,255,0.8)';
+        eyeColor = '#fff';
+    }
+    ctx.fillStyle = bodyColor;
     ctx.fill();
     ctx.strokeStyle = '#333';
     ctx.lineWidth = 3;
@@ -856,7 +867,7 @@ function drawZombie(zombie) {
     ctx.beginPath();
     ctx.arc(x + ex, y + ey, zombie.size * 0.2, 0, Math.PI * 2);
     ctx.arc(x - ex, y - ey, zombie.size * 0.2, 0, Math.PI * 2);
-    ctx.fillStyle = '#ccc';
+    ctx.fillStyle = eyeColor;
     ctx.fill();
     const nx = Math.cos(angle) * zombie.size * 0.6;
     const ny = Math.sin(angle) * zombie.size * 0.6;

--- a/server.js
+++ b/server.js
@@ -154,6 +154,13 @@ function createZombie(x, y, ownerId = null, minionType = 'attack') {
         healer: { speed: 1, damage: 0 },
         ranged: { speed: 1, damage: 2 }
     }[minionType] || { speed: 1.2, damage: 2 };
+
+    // Different minion roles manifest as different creature types when
+    // summoned by a player. Wild zombies remain the default.
+    const kind = ownerId
+        ? ({ attack: 'zombie', healer: 'spirit', ranged: 'skeleton' }[minionType] || 'zombie')
+        : 'zombie';
+
     return {
         id: nextZombieId++,
         x,
@@ -176,7 +183,8 @@ function createZombie(x, y, ownerId = null, minionType = 'attack') {
         burn: 0,
         slow: 0,
         ownerId,
-        minionType
+        minionType,
+        kind
     };
 }
 


### PR DESCRIPTION
## Summary
- Different summoner skills now create unique minion types (zombies, spirits, skeletons)
- Client rendering updated to display new summon appearances

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b787f2b1788328bc6ae4e515d55de4