### PR TITLE
Allow mobs to attack summoned minions and rebalance minions

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -930,6 +930,11 @@ function drawProjectile(p) {
         ctx.beginPath();
         ctx.arc(p.x, p.y, 8, 0, Math.PI * 2);
         ctx.fill();
+    } else if (p.type === 'minion') {
+        ctx.fillStyle = 'white';
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 8, 0, Math.PI * 2);
+        ctx.fill();
     } else {
         ctx.drawImage(fireBallImg, p.x - 8, p.y - 8, 16, 16);
     }


### PR DESCRIPTION
## Summary
- Stop fire staff drops when summons kill boars
- Let hostile mobs target summoned minions and reduce summon health
- Replace ranged minion fireballs with single-hit white projectiles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b82b04fd1483289338025e261be4fe