### PR TITLE
feat: expand combat and skill tree

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -230,6 +230,7 @@ function updateLevelUI() {
         const skill = node.dataset.skill;
         const unlocked = me.class === skill;
         const available = me.skills && me.skills.range && !me.class;
+        node.classList.toggle('hidden', me.class && me.class !== skill);
         node.classList.toggle('unlocked', unlocked);
         node.classList.toggle('locked', !(unlocked || available));
     });
@@ -239,12 +240,9 @@ function updateLevelUI() {
     knightSkillNodes.forEach(node => {
         const skill = node.dataset.skill;
         const unlocked = me.knightSkills && me.knightSkills[skill];
-        let available = me.class === 'knight' && me.skillPoints > 0 && !unlocked;
-        const prereq = knightSkillPrereqs[skill];
-        if (prereq) available = available && me.knightSkills && me.knightSkills[prereq];
-        node.classList.toggle('hidden', !(unlocked || available));
+        node.classList.remove('hidden');
         node.classList.toggle('unlocked', unlocked);
-        node.classList.toggle('locked', !(unlocked || available));
+        node.classList.toggle('locked', !unlocked);
     });
     summonerSkillNodes.forEach(node => {
         const available = me.class === 'summoner' && me.skillPoints > 0;
@@ -254,12 +252,9 @@ function updateLevelUI() {
     mageSkillNodes.forEach(node => {
         const skill = node.dataset.skill;
         const unlocked = me.mageSkills && me.mageSkills[skill];
-        let available = me.class === 'mage' && me.skillPoints > 0 && !unlocked;
-        if (skill === 'mage-slow-extend') available = available && me.mageSkills && me.mageSkills['mage-slow'];
-        if (skill === 'mage-bind') available = available && me.mageSkills && me.mageSkills['mage-slow-extend'];
-        node.classList.toggle('hidden', !(unlocked || available));
+        node.classList.remove('hidden');
         node.classList.toggle('unlocked', unlocked);
-        node.classList.toggle('locked', !(unlocked || available));
+        node.classList.toggle('locked', !unlocked);
     });
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -65,8 +65,8 @@
                         <div id="skill-mage-mana" class="skill-node locked" data-skill="mage-mana">More Mana</div>
                         <div id="skill-mage-regen" class="skill-node locked" data-skill="mage-regen">Faster Mana Regen</div>
                         <div id="skill-mage-slow" class="skill-node locked" data-skill="mage-slow">Slow Spell (Space)</div>
-                        <div id="skill-mage-slow-extend" class="skill-node locked hidden" data-skill="mage-slow-extend">Extend Slow to 10s</div>
-                        <div id="skill-mage-bind" class="skill-node locked hidden" data-skill="mage-bind">Binding Spell (Space)</div>
+                        <div id="skill-mage-slow-extend" class="skill-node locked" data-skill="mage-slow-extend">Extend Slow to 10s</div>
+                        <div id="skill-mage-bind" class="skill-node locked" data-skill="mage-bind">Binding Spell (Space)</div>
                     </div>
                 </div>
                 <div class="class-column">
@@ -75,9 +75,9 @@
                         <div id="skill-knight-damage" class="skill-node locked" data-skill="knight-damage">Sword Damage</div>
                         <div id="skill-knight-speed" class="skill-node locked" data-skill="knight-speed">Speed</div>
                         <div id="skill-knight-health" class="skill-node locked" data-skill="knight-health">Health</div>
-                        <div id="skill-knight-bow-range" class="skill-node locked hidden" data-skill="knight-bow-range">Bow Range</div>
-                        <div id="skill-knight-bow-damage" class="skill-node locked hidden" data-skill="knight-bow-damage">Bow Damage</div>
-                        <div id="skill-knight-shield" class="skill-node locked hidden" data-skill="knight-shield">Shield Dash (Space)</div>
+                        <div id="skill-knight-bow-range" class="skill-node locked" data-skill="knight-bow-range">Bow Range</div>
+                        <div id="skill-knight-bow-damage" class="skill-node locked" data-skill="knight-bow-damage">Bow Damage</div>
+                        <div id="skill-knight-shield" class="skill-node locked" data-skill="knight-shield">Shield Dash (Space)</div>
                     </div>
                 </div>
                 <div class="class-column">

--- a/public/style.css
+++ b/public/style.css
@@ -247,9 +247,6 @@ canvas {
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.7);
-    display: flex;
-    justify-content: center;
-    align-items: center;
     pointer-events: auto;
 }
 #skill-tree.hidden { display: none; }
@@ -263,6 +260,12 @@ canvas {
     border-radius: 10px;
     color: white;
     text-align: center;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow: auto;
 }
 .skill-node {
     background: #444;


### PR DESCRIPTION
## Summary
- Allow player dash to propel forward gradually and inflict contact damage
- Enable Ork fireballs to break wood and stone structures
- Simplify PvP check and widen visibility of skill tree options

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb635fc0f88328b38c89c41eba843e