### PR TITLE
Add whirlwind spin, missile redesign, ability renames, and skill tree styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -78,7 +78,7 @@
                         <div id="skill-knight-health" class="skill-node locked" data-skill="knight-health">Health</div>
                         <div id="skill-knight-bow-range" class="skill-node locked" data-skill="knight-bow-range">Bow Range</div>
                         <div id="skill-knight-bow-damage" class="skill-node locked" data-skill="knight-bow-damage">Bow Damage</div>
-                        <div id="skill-knight-shield" class="skill-node locked" data-skill="knight-shield">Shield Dash (Space)</div>
+                        <div id="skill-knight-shield" class="skill-node locked" data-skill="knight-shield">Dash (Space)</div>
                         <div id="skill-knight-whirlwind" class="skill-node locked" data-skill="knight-whirlwind">Whirlwind (Space)</div>
                     </div>
                 </div>

--- a/public/style.css
+++ b/public/style.css
@@ -275,12 +275,53 @@ canvas {
     margin: 10px auto;
     width: 150px;
     cursor: pointer;
+    position: relative;
 }
 .skill-node.locked { opacity: 0.5; cursor: default; }
 .skill-node.unlocked { border-color: #fff; }
 
-.class-row { display: flex; justify-content: space-between; gap: 10px; }
-.class-column { display: flex; flex-direction: column; align-items: center; }
+.class-row { display: flex; justify-content: space-between; gap: 40px; position: relative; margin-top: 40px; }
+.class-column { display: flex; flex-direction: column; align-items: center; position: relative; }
+.class-column::before {
+    content: '';
+    position: absolute;
+    top: -20px;
+    left: 50%;
+    width: 2px;
+    height: 20px;
+    background: #888;
+}
+.class-column .skill-node::before {
+    content: '';
+    position: absolute;
+    top: -20px;
+    left: 50%;
+    width: 2px;
+    height: 20px;
+    background: #888;
+}
+.class-column .skill-node:first-child::before { display: none; }
+
+#skill-range { position: relative; margin-bottom: 40px; }
+#skill-range::after {
+    content: '';
+    position: absolute;
+    bottom: -20px;
+    left: 50%;
+    width: 2px;
+    height: 20px;
+    background: #888;
+}
+.class-row::before {
+    content: '';
+    position: absolute;
+    top: -20px;
+    left: 50%;
+    width: calc(100% - 80px);
+    height: 2px;
+    background: #888;
+    transform: translateX(-50%);
+}
 
 /* Notifications */
 #notifications {

--- a/server.js
+++ b/server.js
@@ -326,7 +326,6 @@ function levelUp(player, ws) {
         player.maxMana += 20;
         player.mana += 20;
         player.manaRegen = (player.manaRegen || 0) + (0.5 / 60);
-        player.canSlow = true;
     }
     sendLevelUpdate(ws, player);
 }
@@ -498,6 +497,7 @@ wss.on('connection', ws => {
         attackRange: 0,
         dashCooldown: 0,
         whirlwindCooldown: 0,
+        whirlwindTime: 0,
         dashVX: 0,
         dashVY: 0,
         dashTime: 0,
@@ -828,6 +828,7 @@ wss.on('connection', ws => {
             case 'knight-whirlwind': {
                 if (player.class === 'knight' && player.knightSkills && player.knightSkills['knight-whirlwind'] && player.whirlwindCooldown <= 0) {
                     player.whirlwindCooldown = 180;
+                    player.whirlwindTime = 20;
                     handleWhirlwindDamage(player, playerId);
                 }
                 break;
@@ -1081,7 +1082,7 @@ function gameLoop() {
             else if (proj.targetType === 'ogre') target = ogres.find(o => o.id === proj.targetId);
             if (target) {
                 const angle = Math.atan2(target.y - proj.y, target.x - proj.x);
-                const speed = 6;
+                const speed = 2;
                 proj.vx = Math.cos(angle) * speed;
                 proj.vy = Math.sin(angle) * speed;
             } else {
@@ -1564,6 +1565,7 @@ function gameLoop() {
         if (p.invulnerable && p.invulnerable > 0) p.invulnerable--;
         if (p.dashCooldown && p.dashCooldown > 0) p.dashCooldown--;
         if (p.whirlwindCooldown && p.whirlwindCooldown > 0) p.whirlwindCooldown--;
+        if (p.whirlwindTime && p.whirlwindTime > 0) p.whirlwindTime--;
         if (p.dashTime && p.dashTime > 0) {
             p.x = Math.max(0, Math.min(WORLD_WIDTH, p.x + p.dashVX));
             p.y = Math.max(0, Math.min(WORLD_HEIGHT, p.y + p.dashVY));


### PR DESCRIPTION
## Summary
- Spin knights while whirlwind ability is active and track spin duration
- Rework mage missile to a slower, directional projectile
- Rename knight abilities (shield→dash, sword→non) and style skill tree with connecting lines
- Stop auto-unlocking mage slow spell on level up

## Testing
- `node --check server.js`
- `node --check public/client.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb7a41983c8328808c5d62f363d1af