### PR TITLE
Expand whirlwind range and improve ogre interactions

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -673,7 +673,9 @@ function playerMovement() {
     if (!collision) {
         player.x = predictedX;
         player.y = predictedY;
-        socket.send(JSON.stringify({ type: 'move', x: player.x, y: player.y }));
+        if (socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: 'move', x: player.x, y: player.y }));
+        }
     }
 }
 canvas.addEventListener('mousedown', e => {


### PR DESCRIPTION
## Summary
- Increase whirlwind radius and allow it to slay ogres, granting rewards
- Let dash ability kill ogres and drop loot
- Guard client movement messages against closed WebSocket errors

## Testing
- `node server.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7fadf2048328a4acf30d17e03556