### PR TITLE
Add attack cooldown bar and rogue smoke bomb

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
     <div id="ui-container">
         <div id="player-health-bar"><div id="player-health-fill"></div></div>
         <div id="player-mana-bar"><div id="player-mana-fill"></div></div>
+        <div id="player-attack-bar" class="hidden"><div id="player-attack-fill"></div></div>
         <!-- ... hotbar, clock, chat ... (no changes here) -->
         <div id="hotbar">
             <div class="slot" id="hotbar-0">1</div>
@@ -92,6 +93,7 @@
                 <div id="skill-rogue" class="skill-node locked" data-skill="rogue">Rogue</div>
                 <div id="rogue-skills" class="class-skills hidden">
                     <div id="skill-rogue-bomb" class="skill-node locked" data-skill="rogue-bomb">Bomb (Space)</div>
+                    <div id="skill-rogue-smoke" class="skill-node locked" data-skill="rogue-smoke">Smoke Bomb (Space)</div>
                     <div id="skill-rogue-teleport" class="skill-node locked" data-skill="rogue-teleport">Teleport (Space)</div>
                     <div id="skill-rogue-bow" class="skill-node locked" data-skill="rogue-bow">Bow Mastery</div>
                 </div>

--- a/public/style.css
+++ b/public/style.css
@@ -55,6 +55,22 @@ canvas {
 }
 #player-mana-bar.hidden { display: none; }
 
+#player-attack-bar {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    width: 20px;
+    height: 200px;
+    background: #444;
+    border: 2px solid #333;
+}
+#player-attack-fill {
+    width: 100%;
+    height: 100%;
+    background: yellow;
+}
+#player-attack-bar.hidden { display: none; }
+
 /* Hotbar */
 #hotbar {
     position: absolute;


### PR DESCRIPTION
## Summary
- show a cooldown bar when performing non-mana attacks
- add rogue smoke bomb ability with grey vision cloud
- improve mob pathfinding and chasing persistence

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc7632f33c8328a57d12e8f83be398