### PR TITLE
Add character customization and world tweaks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -120,10 +120,27 @@
     <div id="pre-spawn-screen" class="hidden">
         <h2>Choose your name</h2>
         <input type="text" id="name-input" maxlength="20">
-        <h2>Choose your color</h2>
-        <input type="color" id="color-input" value="#ff0000">
-        <h2>Choose your eye color</h2>
-        <input type="color" id="eye-color-input" value="#cccccc">
+        <button id="customize-btn">Customize Character</button>
+        <div id="customization-panel" class="hidden">
+            <div class="options">
+                <h3>Color</h3>
+                <input type="color" id="color-input" value="#ff0000">
+                <h3>Eye Color</h3>
+                <input type="color" id="eye-color-input" value="#cccccc">
+                <h3>Mouth Type</h3>
+                <select id="mouth-select">
+                    <option value="line">Line</option>
+                    <option value="square">Square</option>
+                    <option value="circle">Circle</option>
+                    <option value="oval">Oval</option>
+                    <option value="diamond">Diamond</option>
+                    <option value="triangle">Triangle</option>
+                </select>
+                <h3>Mouth Color</h3>
+                <input type="color" id="mouth-color-input" value="#000000">
+            </div>
+            <canvas id="preview-canvas" width="100" height="100"></canvas>
+        </div>
         <button id="start-btn">Start</button>
     </div>
 

--- a/public/style.css
+++ b/public/style.css
@@ -448,6 +448,24 @@ canvas {
     text-align: center;
     pointer-events: auto;
 }
+#customization-panel {
+    margin-top: 10px;
+    display: flex;
+    gap: 20px;
+    justify-content: center;
+    align-items: center;
+}
+#customization-panel.hidden { display: none; }
+#customization-panel .options {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    text-align: left;
+}
+#preview-canvas {
+    border: 1px solid #fff;
+    background: #222;
+}
 #controls-screen.hidden, #class-screen.hidden, #pre-spawn-screen.hidden, #death-screen.hidden { display: none; }
 #controls-screen button, #class-screen button, #pre-spawn-screen button, #death-screen button { margin-top: 10px; padding: 8px 16px; }
 


### PR DESCRIPTION
## Summary
- Add Customize Character flow with color, eye and mouth selections and live preview
- Remove global left-click attack cooldown for smoother combat
- Spawn players in woods, add wall gating plains, and let rock golem crush resources

## Testing
- `node server.js` *(fails: process terminated after manual run)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc8ec35f208328b8a7ea2b1034b84d