### PR TITLE
feat: add customizable outlines and safer zombie spawn

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -119,6 +119,7 @@ const preSpawnScreen = document.getElementById('pre-spawn-screen');
 const nameInput = document.getElementById('name-input');
 const colorInput = document.getElementById('color-input');
 const eyeColorInput = document.getElementById('eye-color-input');
+const outlineColorInput = document.getElementById('outline-color-input');
 const customizeBtn = document.getElementById('customize-btn');
 const customizationPanel = document.getElementById('customization-panel');
 const mouthSelect = document.getElementById('mouth-select');
@@ -185,47 +186,50 @@ function renderMouth(ctx, x, y, size, type, color) {
     ctx.fillStyle = color;
     ctx.strokeStyle = color;
     ctx.lineWidth = 2;
-    switch (type) {
-        case 'line':
-            ctx.beginPath();
-            ctx.moveTo(x - size, y);
-            ctx.lineTo(x + size, y);
-            ctx.stroke();
-            break;
-        case 'square':
-            ctx.fillRect(x - size, y - size, size * 2, size * 2);
-            break;
-        case 'circle':
-            ctx.beginPath();
-            ctx.arc(x, y, size, 0, Math.PI * 2);
-            ctx.fill();
-            break;
-        case 'oval':
-            ctx.save();
-            ctx.translate(x, y);
-            ctx.scale(1.5, 1);
-            ctx.beginPath();
-            ctx.arc(0, 0, size, 0, Math.PI * 2);
-            ctx.restore();
-            ctx.fill();
-            break;
-        case 'diamond':
-            ctx.beginPath();
-            ctx.moveTo(x, y - size);
-            ctx.lineTo(x + size, y);
-            ctx.lineTo(x, y + size);
-            ctx.lineTo(x - size, y);
-            ctx.closePath();
-            ctx.fill();
-            break;
-        case 'triangle':
-            ctx.beginPath();
-            ctx.moveTo(x, y - size);
-            ctx.lineTo(x + size, y + size);
-            ctx.lineTo(x - size, y + size);
-            ctx.closePath();
-            ctx.fill();
-            break;
+    if (type === 'line') {
+        ctx.beginPath();
+        ctx.moveTo(x - size, y);
+        ctx.lineTo(x + size, y);
+        ctx.stroke();
+        return;
+    }
+    if (type === 'square') {
+        ctx.fillRect(x - size, y - size, size * 2, size * 2);
+        return;
+    }
+    if (type === 'circle') {
+        ctx.beginPath();
+        ctx.arc(x, y, size, 0, Math.PI * 2);
+        ctx.fill();
+        return;
+    }
+    if (type === 'oval') {
+        ctx.save();
+        ctx.translate(x, y);
+        ctx.scale(1.5, 1);
+        ctx.beginPath();
+        ctx.arc(0, 0, size, 0, Math.PI * 2);
+        ctx.restore();
+        ctx.fill();
+        return;
+    }
+    if (type === 'diamond') {
+        ctx.beginPath();
+        ctx.moveTo(x, y - size);
+        ctx.lineTo(x + size, y);
+        ctx.lineTo(x, y + size);
+        ctx.lineTo(x - size, y);
+        ctx.closePath();
+        ctx.fill();
+        return;
+    }
+    if (type === 'triangle') {
+        ctx.beginPath();
+        ctx.moveTo(x, y - size);
+        ctx.lineTo(x + size, y + size);
+        ctx.lineTo(x - size, y + size);
+        ctx.closePath();
+        ctx.fill();
     }
 }
 
@@ -259,7 +263,7 @@ if (customizeBtn) customizeBtn.onclick = () => {
     customizationPanel.classList.toggle('hidden');
     drawPreview();
 };
-[colorInput, eyeColorInput, mouthSelect, mouthColorInput].forEach(el => {
+[colorInput, eyeColorInput, outlineColorInput, mouthSelect, mouthColorInput].forEach(el => {
     if (el) el.addEventListener('input', drawPreview);
 });
 function drawPreview() {
@@ -272,7 +276,7 @@ function drawPreview() {
     previewCtx.arc(x, y, size, 0, Math.PI * 2);
     previewCtx.fillStyle = colorInput.value;
     previewCtx.fill();
-    previewCtx.strokeStyle = '#333';
+    previewCtx.strokeStyle = outlineColorInput.value;
     previewCtx.lineWidth = 3;
     previewCtx.stroke();
     previewCtx.beginPath();
@@ -287,7 +291,7 @@ classButtons.forEach(btn => {
         const cls = btn.dataset.class;
         classScreen.classList.add('hidden');
         preSpawn = false;
-        socket.send(JSON.stringify({ type: 'set-name', name: nameInput.value || 'Survivor', color: colorInput.value, eyeColor: eyeColorInput.value, mouth: mouthSelect.value, mouthColor: mouthColorInput.value }));
+        socket.send(JSON.stringify({ type: 'set-name', name: nameInput.value || 'Survivor', color: colorInput.value, eyeColor: eyeColorInput.value, outlineColor: outlineColorInput.value, mouth: mouthSelect.value, mouthColor: mouthColorInput.value }));
         socket.send(JSON.stringify({ type: 'set-class', class: cls }));
     };
 });
@@ -960,7 +964,7 @@ function drawPlayer(player, isMe) {
     ctx.arc(x, y, player.size, 0, Math.PI * 2);
     ctx.fillStyle = player.color || (isMe ? 'hsl(120, 100%, 70%)' : 'hsl(0, 100%, 70%)');
     ctx.fill();
-    ctx.strokeStyle = '#333';
+    ctx.strokeStyle = player.outlineColor || '#333';
     ctx.lineWidth = 3;
     ctx.stroke();
     let angle = 0;
@@ -1112,7 +1116,7 @@ function drawZombie(zombie) {
     ctx.arc(x, y, zombie.size, 0, Math.PI * 2);
 
     // Pick colors based on the creature type for visual distinction.
-    let bodyColor = '#ff0000'; // default zombie now red
+    let bodyColor = '#00ff00'; // default zombie now green
     let eyeColor = '#ccc';
     if (zombie.kind === 'skeleton') {
         bodyColor = '#ddd';

--- a/public/index.html
+++ b/public/index.html
@@ -127,6 +127,8 @@
                 <input type="color" id="color-input" value="#ff0000">
                 <h3>Eye Color</h3>
                 <input type="color" id="eye-color-input" value="#cccccc">
+                <h3>Outline Color</h3>
+                <input type="color" id="outline-color-input" value="#333333">
                 <h3>Mouth Type</h3>
                 <select id="mouth-select">
                     <option value="line">Line</option>

--- a/server.js
+++ b/server.js
@@ -200,14 +200,14 @@ function getFreePosition() {
     return { x, y };
 }
 
-function getSpawnPositionAround(x, y, radius) {
-    let nx, ny;
+function getSpawnPositionAround(x, y, radius, minDist = 0) {
+    let nx, ny, dist;
     do {
         const angle = Math.random() * Math.PI * 2;
-        const dist = Math.random() * radius;
+        dist = minDist + Math.random() * (radius - minDist);
         nx = x + Math.cos(angle) * dist;
         ny = y + Math.sin(angle) * dist;
-    } while (isBlocked(nx, ny, 20));
+    } while (isBlocked(nx, ny, 20) || collidesWithEntities(nx, ny, 20));
     return { x: nx, y: ny };
 }
 
@@ -672,6 +672,7 @@ wss.on('connection', ws => {
         burn: 0,
         slow: 0,
         eyeColor: '#ccc',
+        outlineColor: '#333',
         mouth: 'line',
         mouthColor: '#000',
         mana: 100,
@@ -751,6 +752,7 @@ wss.on('connection', ws => {
                 if (typeof data.name === 'string') player.name = data.name.slice(0, 20);
                 if (typeof data.color === 'string') player.color = data.color;
                 if (typeof data.eyeColor === 'string') player.eyeColor = data.eyeColor;
+                if (typeof data.outlineColor === 'string') player.outlineColor = data.outlineColor;
                 if (typeof data.mouth === 'string') player.mouth = data.mouth;
                 if (typeof data.mouthColor === 'string') player.mouthColor = data.mouthColor;
                 if (!player.active) {
@@ -1842,7 +1844,7 @@ function gameLoop() {
             const minions = zombies.filter(z => z.bossId === zombie.id);
             if (minions.length === 0 && zombie.spawnCooldown <= 0) {
                 for (let i = 0; i < 3; i++) {
-                    const { x: nx, y: ny } = getSpawnPositionAround(zombie.x, zombie.y, 60);
+                    const { x: nx, y: ny } = getSpawnPositionAround(zombie.x, zombie.y, 80, zombie.size + 20);
                     zombies.push(createZombie(nx, ny, null, 'attack', 'tree', zombie.id));
                 }
                 zombie.spawnCooldown = 600;


### PR DESCRIPTION
## Summary
- allow players to pick custom outline colors and draw only their chosen mouth
- make regular zombies green
- prevent big zombies from spawning minions on top of themselves

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bccc03421883288ffc4854e17c60df