### PR TITLE
Add flame spell and improve missile mechanics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,7 @@
                     <div id="mage-skills" class="class-skills hidden">
                         <div id="skill-mage-mana" class="skill-node locked" data-skill="mage-mana">More Mana</div>
                         <div id="skill-mage-regen" class="skill-node locked" data-skill="mage-regen">Faster Mana Regen</div>
+                        <div id="skill-mage-flame" class="skill-node locked" data-skill="mage-flame">Flame Spell (Space)</div>
                         <div id="skill-mage-slow" class="skill-node locked" data-skill="mage-slow">Slow Spell (Space)</div>
                         <div id="skill-mage-slow-extend" class="skill-node locked" data-skill="mage-slow-extend">Extend Slow to 10s</div>
                         <div id="skill-mage-bind" class="skill-node locked" data-skill="mage-bind">Binding Spell (Space)</div>

--- a/public/style.css
+++ b/public/style.css
@@ -339,9 +339,10 @@ canvas {
 #mage-skills { grid-template-columns: repeat(3, 150px); }
 #skill-mage-mana { grid-column: 1; grid-row: 1; }
 #skill-mage-regen { grid-column: 2; grid-row: 1; }
+#skill-mage-flame { grid-column: 2; grid-row: 2; }
 #skill-mage-slow { grid-column: 3; grid-row: 1; }
 #skill-mage-missile { grid-column: 1; grid-row: 2; }
-#skill-mage-missile-upgrade { grid-column: 2; grid-row: 2; }
+#skill-mage-missile-upgrade { grid-column: 1; grid-row: 3; }
 #skill-mage-slow-extend { grid-column: 3; grid-row: 2; }
 #skill-mage-bind { grid-column: 3; grid-row: 3; }
 


### PR DESCRIPTION
## Summary
- Add Flame mage upgrade that unlocks a low-cost red cloud applying burn
- Make missiles seek only forward targets and let missile upgrade fire two shots
- Reposition missile upgrade node below missile and add Flame node in skill tree

## Testing
- `node --check server.js`
- `node --check public/client.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2c3de1c8328bc02525fbd378df9