### PR TITLE
Add sun damage, knight range skill, and bomb behavior tweaks

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -150,11 +150,13 @@ const knightSkillNodes = [
     document.getElementById('skill-knight-speed'),
     document.getElementById('skill-knight-health'),
     document.getElementById('skill-knight-shield'),
-    document.getElementById('skill-knight-whirlwind')
+    document.getElementById('skill-knight-whirlwind'),
+    document.getElementById('skill-knight-attack-range')
 ];
 const knightSkillPrereqs = {
     'knight-shield': 'knight-speed',
-    'knight-whirlwind': 'knight-damage'
+    'knight-whirlwind': 'knight-damage',
+    'knight-attack-range': 'knight-whirlwind'
 };
 const summonerSkillNodes = [
     document.getElementById('skill-summoner-attack'),
@@ -1272,7 +1274,7 @@ function drawProjectile(p) {
         ctx.arc(p.x, p.y, 8, 0, Math.PI * 2);
         ctx.fill();
     } else if (p.type === 'smoke') {
-        const radius = p.radius || 60;
+        const radius = p.radius || 120;
         const me = players[myPlayerId];
         const inner = me && me.class === 'rogue' ? 'rgba(128,128,128,0.4)' : 'rgba(90,90,90,0.6)';
         const outer = me && me.class === 'rogue' ? 'rgba(128,128,128,0)' : 'rgba(90,90,90,0)';
@@ -1427,12 +1429,10 @@ function render() {
     if (me) {
         for (const p of projectiles) {
             if (p.type === 'smoke') {
-                const radius = p.radius || 60;
+                const radius = p.radius || 120;
                 if (Math.hypot(me.x - p.x, me.y - p.y) < radius) {
-                    if (me.class !== 'rogue') {
-                        ctx.fillStyle = 'rgba(128,128,128,0.6)';
-                        ctx.fillRect(0, 0, canvas.width, canvas.height);
-                    }
+                    ctx.fillStyle = 'gray';
+                    ctx.fillRect(0, 0, canvas.width, canvas.height);
                     break;
                 }
             }

--- a/public/index.html
+++ b/public/index.html
@@ -81,6 +81,7 @@
                         <div id="skill-knight-health" class="skill-node locked" data-skill="knight-health">Health</div>
                     <div id="skill-knight-shield" class="skill-node locked" data-skill="knight-shield">Dash (Space)</div>
                     <div id="skill-knight-whirlwind" class="skill-node locked" data-skill="knight-whirlwind">Whirlwind (Space)</div>
+                    <div id="skill-knight-attack-range" class="skill-node locked" data-skill="knight-attack-range">Attack Range</div>
                 </div>
             </div>
             <div class="class-column">

--- a/public/style.css
+++ b/public/style.css
@@ -352,6 +352,7 @@ canvas {
 #skill-knight-health { grid-column: 3; grid-row: 1; }
 #skill-knight-whirlwind { grid-column: 1; grid-row: 4; }
 #skill-knight-shield { grid-column: 2; grid-row: 2; }
+#skill-knight-attack-range { grid-column: 2; grid-row: 4; }
 
 #summoner-skills { grid-template-columns: repeat(3, 150px); }
 #skill-summoner-attack { grid-column: 1; grid-row: 1; }


### PR DESCRIPTION
## Summary
- Zombies now take periodic damage during daylight.
- Knights can unlock an Attack Range skill after Whirlwind to double their melee reach.
- Smoke bombs have a larger radius, slow to a halt after 2 seconds, and fully gray out the screen.
- Regular bombs bounce off trees and rocks.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` *(server started and logged world generation)*

------
https://chatgpt.com/codex/tasks/task_e_68bd94450df88328a36cb91abb5c7deb