### PR TITLE
Add advanced summoner AI upgrades and lock-on ability

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -87,9 +87,12 @@
             <div class="class-column">
                 <div id="skill-summoner" class="skill-node locked" data-skill="summoner">Summoner</div>
                     <div id="summoner-skills" class="class-skills hidden">
-                        <div id="skill-summoner-attack" class="skill-node locked" data-skill="summoner-attack">+1 Attack Minion</div>
-                        <div id="skill-summoner-healer" class="skill-node locked" data-skill="summoner-healer">+1 Healer Minion</div>
+                    <div id="skill-summoner-attack" class="skill-node locked" data-skill="summoner-attack">+1 Attack Minion</div>
+                    <div id="skill-summoner-healer" class="skill-node locked" data-skill="summoner-healer">+1 Healer Minion</div>
                     <div id="skill-summoner-ranged" class="skill-node locked" data-skill="summoner-ranged">+1 Ranged Minion</div>
+                    <div id="skill-summoner-ranged-stop" class="skill-node locked" data-skill="summoner-ranged-stop">Ranged Hold</div>
+                    <div id="skill-summoner-ranged-flee" class="skill-node locked" data-skill="summoner-ranged-flee">Ranged Kite</div>
+                    <div id="skill-summoner-lockon" class="skill-node locked" data-skill="summoner-lockon">Lock On</div>
                 </div>
             </div>
             <div class="class-column">


### PR DESCRIPTION
## Summary
- add Ranged Hold and Ranged Kite upgrades for summoner ranged minions
- remove manual minion commands and add lock-on skill to focus minions on damaged targets
- support new upgrades on server and client side

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdad57242083289c25df4f576edf56