### PR TITLE
Make blood moon nightly and add sticky bomb upgrade

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -185,11 +185,12 @@ const mageSkillPrereqs = {
 };
 const rogueSkillNodes = [
     document.getElementById('skill-rogue-bomb'),
+    document.getElementById('skill-rogue-sticky'),
     document.getElementById('skill-rogue-smoke'),
     document.getElementById('skill-rogue-teleport'),
     document.getElementById('skill-rogue-bow')
 ];
-const rogueSkillPrereqs = { 'rogue-smoke': 'rogue-bomb' };
+const rogueSkillPrereqs = { 'rogue-smoke': 'rogue-bomb', 'rogue-sticky': 'rogue-bomb' };
 
 function renderMouth(ctx, x, y, size, type, color) {
     ctx.fillStyle = color;
@@ -587,6 +588,7 @@ socket.onmessage = event => {
                     clientPlayer.canBomb = serverPlayer.canBomb;
                     clientPlayer.canSmoke = serverPlayer.canSmoke;
                     clientPlayer.canTeleport = serverPlayer.canTeleport;
+                    clientPlayer.stickyBomb = serverPlayer.stickyBomb;
                     clientPlayer.rogueSkills = serverPlayer.rogueSkills || {};
                     clientPlayer.color = serverPlayer.color;
                     clientPlayer.eyeColor = serverPlayer.eyeColor || '#ccc';

--- a/public/index.html
+++ b/public/index.html
@@ -99,6 +99,7 @@
                 <div id="skill-rogue" class="skill-node locked" data-skill="rogue">Rogue</div>
                 <div id="rogue-skills" class="class-skills hidden">
                     <div id="skill-rogue-bomb" class="skill-node locked" data-skill="rogue-bomb">Bomb (Space)</div>
+                    <div id="skill-rogue-sticky" class="skill-node locked" data-skill="rogue-sticky">Sticky Bomb</div>
                     <div id="skill-rogue-smoke" class="skill-node locked" data-skill="rogue-smoke">Smoke Bomb (Space)</div>
                     <div id="skill-rogue-teleport" class="skill-node locked" data-skill="rogue-teleport">Teleport (Space)</div>
                     <div id="skill-rogue-bow" class="skill-node locked" data-skill="rogue-bow">Bow Mastery</div>

--- a/public/style.css
+++ b/public/style.css
@@ -361,6 +361,8 @@ canvas {
 
 #rogue-skills { grid-template-columns: repeat(3, 150px); }
 #skill-rogue-bomb { grid-column: 1; grid-row: 1; }
+#skill-rogue-smoke { grid-column: 1; grid-row: 2; }
+#skill-rogue-sticky { grid-column: 2; grid-row: 2; }
 #skill-rogue-teleport { grid-column: 2; grid-row: 1; }
 #skill-rogue-bow { grid-column: 3; grid-row: 1; }
 


### PR DESCRIPTION
## Summary
- Trigger blood moons every night for relentless enemy aggression
- Introduce rogue sticky bomb upgrade that clings to mobs but still bounces off terrain
- Add UI elements and client support for sticky bomb skill

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bde80d5a4c83288e356aabdf2ebca9